### PR TITLE
Add support for rEFInd bootloader in Katsu build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN dnf install -y \
     xorriso \
     rpm \
     limine \
+    rEFInd \
     systemd \
     btrfs-progs \
     e2fsprogs \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Katsu uses YAML configuration files to describe the image, with modular manifest
 - `xorriso`
 - `clang-devel`
 - `dracut`
-- `limine` or `grub2`
+- `limine` or `grub2` or `refind`
 - `rpm`
 - `dnf` or `dnf5`
 - `systemd-devel`

--- a/templates/refind.cfg.tera
+++ b/templates/refind.cfg.tera
@@ -1,0 +1,18 @@
+{{ REFIND_PREPEND_COMMENT }}
+
+timeout 20
+
+scan_driver_dirs /EFI/BOOT/drivers_x64,drivers_x64
+
+menuentry "{{ distro }}" {
+    volume   "{{ volid }}"
+    loader   /boot/{{ vmlinuz }}
+    initrd   /boot/{{ initramfs }}
+    options  "root=live:LABEL={{ volid }} rd.live.image enforcing=0 {{ cmd }}"
+    submenuentry "{{ distro }} (Check Image)" {
+        add_options "rd.live.check"
+    }
+    submenuentry "{{ distro }} (nomodeset)" {
+        add_options "nomodeset"
+    }
+}

--- a/tests/ng/katsu-iso-refind.yaml
+++ b/tests/ng/katsu-iso-refind.yaml
@@ -1,0 +1,30 @@
+# Example manifest for a Katsu build
+import:
+  - modules/base.yaml
+  - modules/live-image/live.yaml
+builder: dnf
+distro: Katsu Ultramarine
+
+kernel_cmdline: "quiet splash"
+
+bootloader: refind
+
+dnf:
+  releasever: 39
+  options:
+    - --setopt=keepcache=True
+    - --nogpgcheck
+    - --setopt=cachedir=/var/cache/dnf
+  packages:
+    - dracut-config-generic
+    - dracut-live
+    - dracut-config-generic
+    - dracut-network
+    - anaconda-dracut
+    - dracut-squash
+    - "@xfce-desktop"
+    - anaconda-live
+    - libblockdev-nvdimm
+    - isomd5sum
+    - rEFInd
+    - dosfstools


### PR DESCRIPTION
This PR is still in progress... 

The iso is capable to boot in the rEFInd boot, but the rEFInd cannot find the /boot/vmlinuz location inside the ISO. I don't know why, But I'm trying to make this work

![image](https://github.com/user-attachments/assets/f1220020-0f37-42d4-9d93-296b7e2fdfbe)
